### PR TITLE
Updated redirect for apply page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -11,7 +11,7 @@
 /bugbounty /bug-bounty
 
 #Jobs Redirect
-/apply /jobs
+/apply /jobs/#jobboard
 
 # Technology Section
 /polkadot /technologies/polkadot


### PR DESCRIPTION
Updated redirect link for /apply/JOBID to go directly to the job-board. 