### PR TITLE
Fixing OG Image for blog pages

### DIFF
--- a/src/components/templates/blog-template.tsx
+++ b/src/components/templates/blog-template.tsx
@@ -29,7 +29,7 @@ export default function BlogTemplate(props: BlogTemplateProps) {
     <Layout>
       <SEO
         title={props.data.mdx.frontmatter.blogTitle}
-        image={props.data.mdx.frontmatter.image}
+        image={`https://www.parity.io${props.data.mdx.frontmatter.image}`}
         description={props.data.mdx.excerpt}
         author={props.data.mdx.frontmatter.author}
         keywords={props.data.mdx.frontmatter.tags}


### PR DESCRIPTION
OG Image needs to be an absolute path not relative.  Fixing the bug and deploying to production. 